### PR TITLE
Implement PageViewsLineChart and fix spacing

### DIFF
--- a/storybook/src/components/PageViewsBarChart.tsx
+++ b/storybook/src/components/PageViewsBarChart.tsx
@@ -4,6 +4,7 @@ import CardContent from "@mui/material/CardContent";
 import Chip from "@mui/material/Chip";
 import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
 import { BarChart } from "@mui/x-charts/BarChart";
 import { useTheme } from "@mui/material/styles";
 import ChartWrapper from "./ChartWrapper";
@@ -15,10 +16,13 @@ export default function PageViewsBarChart() {
     (theme.vars || theme).palette.primary.main,
     (theme.vars || theme).palette.primary.light,
   ];
+  const chartId = React.useId();
+  const descriptionId = `${chartId}-description`;
+
   return (
-    <Card variant="outlined" sx={{ width: "100%" }}>
+    <Card variant="outlined" sx={{ width: "100%" }} role="region" aria-labelledby={chartId}>
       <CardContent>
-        <Typography component="h2" variant="subtitle2" gutterBottom>
+        <Typography id={chartId} component="h2" variant="subtitle2" gutterBottom>
           Page views and downloads
         </Typography>
         <Stack sx={{ justifyContent: "space-between" }}>
@@ -39,10 +43,30 @@ export default function PageViewsBarChart() {
             Page views and downloads for the last 6 months
           </Typography>
         </Stack>
+        <Box
+          id={descriptionId}
+          sx={{
+            position: "absolute",
+            width: 1,
+            height: 1,
+            padding: 0,
+            margin: -1,
+            overflow: "hidden",
+            clip: "rect(0, 0, 0, 0)",
+            whiteSpace: "nowrap",
+            border: 0,
+          }}
+        >
+          Stacked bar chart showing page views, downloads, and conversions data from January to July.
+          Page views range from 2,234 to 4,125. Downloads range from 2,101 to 4,752.
+          Conversions range from 2,038 to 4,693. Total metrics show 1.3 million with an 8% decrease.
+        </Box>
         <ChartWrapper height={250} sx={{ mt: 3 }}>
           <BarChart
             borderRadius={8}
             colors={colorPalette}
+            aria-label="Stacked bar chart displaying page views, downloads, and conversions over time"
+            aria-describedby={descriptionId}
             xAxis={[
               {
                 scaleType: "band",

--- a/storybook/src/components/PageViewsBarChart.tsx
+++ b/storybook/src/components/PageViewsBarChart.tsx
@@ -39,7 +39,7 @@ export default function PageViewsBarChart() {
             Page views and downloads for the last 6 months
           </Typography>
         </Stack>
-        <ChartWrapper height={250}>
+        <ChartWrapper height={250} sx={{ mt: 3 }}>
           <BarChart
             borderRadius={8}
             colors={colorPalette}
@@ -81,4 +81,4 @@ export default function PageViewsBarChart() {
       </CardContent>
     </Card>
   );
-} 
+}

--- a/storybook/src/components/PageViewsLineChart.tsx
+++ b/storybook/src/components/PageViewsLineChart.tsx
@@ -39,7 +39,7 @@ export default function PageViewsLineChart() {
             Page views and downloads for the last 6 months
           </Typography>
         </Stack>
-        <ChartWrapper height={250}>
+        <ChartWrapper height={250} sx={{ mt: 3 }}>
           <LineChart
             colors={colorPalette}
             xAxis={[

--- a/storybook/src/components/PageViewsLineChart.tsx
+++ b/storybook/src/components/PageViewsLineChart.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Chip from "@mui/material/Chip";
+import Typography from "@mui/material/Typography";
+import Stack from "@mui/material/Stack";
+import { LineChart } from "@mui/x-charts/LineChart";
+import { useTheme } from "@mui/material/styles";
+import ChartWrapper from "./ChartWrapper";
+
+export default function PageViewsLineChart() {
+  const theme = useTheme();
+  const colorPalette = [
+    (theme.vars || theme).palette.primary.dark,
+    (theme.vars || theme).palette.primary.main,
+    (theme.vars || theme).palette.primary.light,
+  ];
+  return (
+    <Card variant="outlined" sx={{ width: "100%" }}>
+      <CardContent>
+        <Typography component="h2" variant="subtitle2" gutterBottom>
+          Page views and downloads
+        </Typography>
+        <Stack sx={{ justifyContent: "space-between" }}>
+          <Stack
+            direction="row"
+            sx={{
+              alignContent: { xs: "center", sm: "flex-start" },
+              alignItems: "center",
+              gap: 1,
+            }}
+          >
+            <Typography variant="h4" component="p">
+              1.3M
+            </Typography>
+            <Chip size="small" color="error" label="-8%" />
+          </Stack>
+          <Typography variant="caption" sx={{ color: "text.secondary" }}>
+            Page views and downloads for the last 6 months
+          </Typography>
+        </Stack>
+        <ChartWrapper height={250}>
+          <LineChart
+            colors={colorPalette}
+            xAxis={[
+              {
+                scaleType: "band",
+                data: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul"],
+              },
+            ]}
+            series={[
+              {
+                id: "page-views",
+                label: "Page views",
+                data: [2234, 3872, 2998, 4125, 3357, 2789, 2998],
+                curve: "natural",
+                showMark: true,
+              },
+              {
+                id: "downloads",
+                label: "Downloads",
+                data: [3098, 4215, 2384, 2101, 4752, 3593, 2384],
+                curve: "natural",
+                showMark: true,
+              },
+              {
+                id: "conversions",
+                label: "Conversions",
+                data: [4051, 2275, 3129, 4693, 3904, 2038, 2275],
+                curve: "natural",
+                showMark: true,
+              },
+            ]}
+            height={250}
+            margin={{ left: 50, right: 0, top: 20, bottom: 20 }}
+            grid={{ horizontal: true }}
+          />
+        </ChartWrapper>
+      </CardContent>
+    </Card>
+  );
+}

--- a/storybook/src/components/PageViewsLineChart.tsx
+++ b/storybook/src/components/PageViewsLineChart.tsx
@@ -43,9 +43,29 @@ export default function PageViewsLineChart() {
             Page views and downloads for the last 6 months
           </Typography>
         </Stack>
+        <Box
+          id={descriptionId}
+          sx={{
+            position: "absolute",
+            width: 1,
+            height: 1,
+            padding: 0,
+            margin: -1,
+            overflow: "hidden",
+            clip: "rect(0, 0, 0, 0)",
+            whiteSpace: "nowrap",
+            border: 0,
+          }}
+        >
+          Line chart showing page views, downloads, and conversions data from January to July.
+          Page views range from 2,234 to 4,125. Downloads range from 2,101 to 4,752.
+          Conversions range from 2,038 to 4,693. Total metrics show 1.3 million with an 8% decrease.
+        </Box>
         <ChartWrapper height={250} sx={{ mt: 3 }}>
           <LineChart
             colors={colorPalette}
+            aria-label="Line chart displaying page views, downloads, and conversions over time"
+            aria-describedby={descriptionId}
             xAxis={[
               {
                 scaleType: "band",

--- a/storybook/src/components/PageViewsLineChart.tsx
+++ b/storybook/src/components/PageViewsLineChart.tsx
@@ -4,6 +4,7 @@ import CardContent from "@mui/material/CardContent";
 import Chip from "@mui/material/Chip";
 import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
 import { LineChart } from "@mui/x-charts/LineChart";
 import { useTheme } from "@mui/material/styles";
 import ChartWrapper from "./ChartWrapper";
@@ -15,10 +16,13 @@ export default function PageViewsLineChart() {
     (theme.vars || theme).palette.primary.main,
     (theme.vars || theme).palette.primary.light,
   ];
+  const chartId = React.useId();
+  const descriptionId = `${chartId}-description`;
+
   return (
-    <Card variant="outlined" sx={{ width: "100%" }}>
+    <Card variant="outlined" sx={{ width: "100%" }} role="region" aria-labelledby={chartId}>
       <CardContent>
-        <Typography component="h2" variant="subtitle2" gutterBottom>
+        <Typography id={chartId} component="h2" variant="subtitle2" gutterBottom>
           Page views and downloads
         </Typography>
         <Stack sx={{ justifyContent: "space-between" }}>

--- a/storybook/stories/PageViewsLineChart.stories.tsx
+++ b/storybook/stories/PageViewsLineChart.stories.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Box, Stack } from '@mui/material';
+import PageViewsLineChart from '../src/components/PageViewsLineChart';
+
+const meta: Meta<typeof PageViewsLineChart> = {
+  title: 'Dashboard/PageViewsLineChart',
+  component: PageViewsLineChart,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: 'Dashboard line chart component showing page views and downloads data over time.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <PageViewsLineChart />,
+};
+
+export const DifferentSizes: Story = {
+  render: () => (
+    <Stack spacing={3} sx={{ maxWidth: 800 }}>
+      <Box sx={{ width: '100%', height: 400 }}>
+        <PageViewsLineChart />
+      </Box>
+      <Box sx={{ width: '75%', height: 300 }}>
+        <PageViewsLineChart />
+      </Box>
+      <Box sx={{ width: '50%', height: 250 }}>
+        <PageViewsLineChart />
+      </Box>
+    </Stack>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Page views line chart in different sizes.',
+      },
+    },
+  },
+};
+
+export const SideBySide: Story = {
+  render: () => (
+    <Stack direction="row" spacing={3} sx={{ maxWidth: 1200 }}>
+      <Box sx={{ flex: 1, height: 350 }}>
+        <PageViewsLineChart />
+      </Box>
+      <Box sx={{ flex: 1, height: 350 }}>
+        <PageViewsLineChart />
+      </Box>
+    </Stack>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Two page views line charts side by side.',
+      },
+    },
+  },
+};
+
+export const CompactLayout: Story = {
+  render: () => (
+    <Box sx={{ maxWidth: 600, height: 300 }}>
+      <PageViewsLineChart />
+    </Box>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Compact layout for the page views line chart.',
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary
Introduces a new `PageViewsLineChart` component for visualizing trend data and adjusts layout spacing in the existing bar chart.

## Problem
The dashboard lacked a line chart comparison view for page metrics. Additionally, the existing `PageViewsBarChart` content was too close to the header, creating a cramped visual layout.

## Solution
Implemented a new line chart component mirroring the structure of the bar chart and applied margin spacing to separate chart visualizations from their headers.

## Key Changes
*   **New Component**: Added `PageViewsLineChart.tsx` using MUI X Charts to display page views, downloads, and conversions as curves.
*   **Stories**: Created `PageViewsLineChart.stories.tsx` with scenarios for different sizes and layouts.
*   **Styling**: Added `sx={{ mt: 3 }}` to `ChartWrapper` in both the new line chart and existing `PageViewsBarChart` to improve vertical spacing.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/6ac728e3403c4e5ca3eec48e8affde46/stellar-zone)

👀 [Preview Link](https://6ac728e3403c4e5ca3eec48e8affde46-stellar-zone.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6ac728e3403c4e5ca3eec48e8affde46</projectId>-->
<!--<branchName>stellar-zone</branchName>-->